### PR TITLE
Remove hash-entry and tag-issuer from linked-tags

### DIFF
--- a/concise-mid-tag.cddl
+++ b/concise-mid-tag.cddl
@@ -70,17 +70,7 @@ module-version = {
 linked-tag-entry = {
   0 => $tag-id-type,
   1 => $tag-rel-type,
-  ; tag thumbprint, i.e., digest of the CBOR encoding of the
-  ; concise-tag
-  ? 2 => hash-entry,
-  ; verification key associated with the tag issuer
-  ? 3 => tag-issuer-type,
 }
-
-; Bob is saying: I expect this tag to be provided (signed
-; by) by Alice. The COSE keyset only contains raw /
-; certified public keys.
-tag-issuer-type /= COSE_KeySet
 
 $tag-rel-type /= comid-includes
 $tag-rel-type /= comid-or-includes


### PR DESCRIPTION
This only partially addresses ietf-rats/draft-birkholz-rats-corim#55
The question: "Possibly corim-locator needs an issuer COSE_KeySet?" is
left open.