### PR TITLE
transplant the old world into the new one

### DIFF
--- a/comid-triples-code-points.cddl
+++ b/comid-triples-code-points.cddl
@@ -1,5 +1,22 @@
 ; concise-mid-tag
-comid.triples = 5
+comid.language = 0
+comid.tag-identity = 1
+comid.entity = 2
+comid.linked-tags = 3
+comid.triples = 4
+
+; tag-identity-map
+comid.tag-id = 0
+comid.tag-version = 1
+
+; entity-map
+comid.entity-name = 0
+comid.reg-id = 1
+comid.role = 2
+
+; linked-tag-map
+comid.linked-tag-id = 0
+comid.tag-rel = 1
 
 ; triples-map
 comid.reference-triples = 0
@@ -39,5 +56,14 @@ comid.keychain = 1
 ; version-map
 comid.version = 0
 comid.version-scheme = 1
+
+; The current CoMID has additional triples that augment the
+; triples of the target CoMID.
+comid.supplements = 0
+
+; The current CoMID contains corrections to a previously
+; issued CoMID.  This tag replaces the target tag. The tag-id
+; remains unchanged. The tag-version is incremented.
+comid.replaces = 1
 
 ; vim: set tw=60 ts=2 et:

--- a/comid-triples.cddl
+++ b/comid-triples.cddl
@@ -1,12 +1,38 @@
 concise-mid-tag = {
-  ; TODO(tho) language
-  ; TODO(tho) tag-id
-  ; TODO(tho) module-name
-  ; TODO(tho) entity NOTE(tho) call it entity-map (no module- prefix)
-  ; TODO(tho) linked-tags
+  ? comid.language => language-type
+  comid.tag-identity => tag-identity-map
+  ? comid.entity => one-or-more<entity-map>
+  ? comid.linked-tags => one-or-more<linked-tag-map>
   comid.triples => triples-map
-  ; TODO(tho) extension
+  * $$concise-mid-tag-extension
 }
+
+language-type = text
+
+tag-identity-map = {
+  comid.tag-id => $tag-id-type-choice
+  ? comid.tag-version => tag-version-type
+}
+
+$tag-id-type-choice /= tstr
+$tag-id-type-choice /= uuid-type
+
+tag-version-type = uint .default 0
+
+entity-map = {
+  comid.entity-name => $entity-name-type-choice
+  ? comid.reg-id => uri
+  comid.role => one-or-more<$module-role-type-choice>
+  * $$entity-map-extension
+}
+
+linked-tag-map = {
+  comid.linked-tag-id => $tag-id-type-choice
+  comid.tag-rel => $tag-rel-type-choice
+}
+
+$tag-rel-type-choice /= comid.supplements
+$tag-rel-type-choice /= comid.replaces
 
 triples-map = non-empty<{
   ? comid.reference-triples => one-or-more<reference-triple-record>


### PR DESCRIPTION
As discussed, this PR pulls back all the relevant stuff from the previous CoMID description -- plus the small corrections:
* remove the module- prefix from the entity-map
* drop the module-name object (all triples come with their explicit subject)

Once this is approved, I will `git mv` the two files into the old ones.