### PR TITLE
Save printable copies of the examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,10 @@
 
 SHELL := /bin/bash
 
-%.cbor: %.diag
-	diag2cbor.rb $< > $@
-	cbor2pretty.rb $@
-
 include tools.mk
+
+%.cbor: %.diag
+	$(diag2cbor) $< > $@
 
 check:: check-corim check-corim-examples
 check:: check-xcorim
@@ -31,11 +30,14 @@ check-$(1)-examples: $(1)-autogen.cddl $(3:.diag=.cbor)
 	@for f in $(3:.diag=.cbor); do \
 		echo ">> validating $$$$f against $$<" ; \
 		$$(cddl) $$< validate $$$$f &>/dev/null || exit 1 ; \
+		echo ">> saving prettified CBOR to $$$${f%.cbor}.pretty" ; \
+		$$(cbor2pretty) $$$$f > $$$${f%.cbor}.pretty ; \
 	done
 
 .PHONY: check-$(1)-examples
 
 CLEANFILES += $(3:.diag=.cbor)
+CLEANFILES += $(3:.diag=.pretty)
 
 endef # cddl_check_template
 

--- a/tools.mk
+++ b/tools.mk
@@ -21,3 +21,8 @@ ifeq ($(strip $(diag2cbor)),)
 $(error diag2cbor.rb not found. To install diag2cbor.rb: 'gem install cbor-diag')
 endif
 
+cbor2pretty ?= $(shell command -v cbor2pretty.rb)
+ifeq ($(strip $(cbor2pretty)),)
+$(error cbor2pretty.rb not found. To install cbor2pretty.rb: 'gem install cbor-diag')
+endif
+


### PR DESCRIPTION
Add an makefile action to save the validated examples in
pretty-printable format.  Remove them on make clean.

Fixes #108