### PR TITLE
Nedmsmith patch 3

### DIFF
--- a/comid-code-points.cddl
+++ b/comid-code-points.cddl
@@ -52,6 +52,7 @@ comid.ip-addr = 7
 comid.serial-number = 8
 comid.ueid = 9
 comid.uuid = 10
+comid.model-name = 11
 
 ; verification-key-map
 comid.key = 0

--- a/concise-mid-tag.cddl
+++ b/concise-mid-tag.cddl
@@ -155,7 +155,7 @@ measurement-values-map = non-empty<{
   ? comid.serial-number => serial-number-type
   ? comid.ueid => ueid-type
   ? comid.uuid => uuid-type
-  ? comid.model => tstr
+  ? comid.model-name => tstr
   * $$measurement-values-map-extension
 }>
 

--- a/concise-mid-tag.cddl
+++ b/concise-mid-tag.cddl
@@ -155,6 +155,7 @@ measurement-values-map = non-empty<{
   ? comid.serial-number => serial-number-type
   ? comid.ueid => ueid-type
   ? comid.uuid => uuid-type
+  ? comid.model => tstr
   * $$measurement-values-map-extension
 }>
 


### PR DESCRIPTION
added 'comid.model-name => tstr' to measurement-values-map.