### PR TITLE
change model-name to name

### DIFF
--- a/comid-code-points.cddl
+++ b/comid-code-points.cddl
@@ -52,7 +52,7 @@ comid.ip-addr = 7
 comid.serial-number = 8
 comid.ueid = 9
 comid.uuid = 10
-comid.model-name = 11
+comid.name = 11
 
 ; verification-key-map
 comid.key = 0

--- a/concise-mid-tag.cddl
+++ b/concise-mid-tag.cddl
@@ -155,7 +155,7 @@ measurement-values-map = non-empty<{
   ? comid.serial-number => serial-number-type
   ? comid.ueid => ueid-type
   ? comid.uuid => uuid-type
-  ? comid.model-name => tstr
+  ? comid.name => tstr
   * $$measurement-values-map-extension
 }>
 


### PR DESCRIPTION
content of a string measurement is determined by the environment-map class-id semantics hence the claim tag doesn't need to bias the possible value.