### PR TITLE
Clarification for mkey uint usage

### DIFF
--- a/concise-mid-tag.cddl
+++ b/concise-mid-tag.cddl
@@ -131,9 +131,15 @@ tagged-int-type = #6.551(int)
 ueid-type = bytes .size 33
 tagged-ueid-type = #6.550(ueid-type)
 
+;
+; mkey type definitions
+;
 $measured-element-type-choice /= tagged-oid-type
 $measured-element-type-choice /= tagged-uuid-type
+; The $measured-element-type-choice uint is intended for time series mval data where lower uint
+; values indicate older mval data while higher uint values indicate newer mval data; 0 is an asumed epoch.
 $measured-element-type-choice /= uint
+; Subsequent additions to $measured-element-type-choice should be tagged values.
 
 measurement-map = {
   ? comid.mkey => $measured-element-type-choice

--- a/concise-mid-tag.cddl
+++ b/concise-mid-tag.cddl
@@ -137,7 +137,7 @@ tagged-ueid-type = #6.550(ueid-type)
 $measured-element-type-choice /= tagged-oid-type
 $measured-element-type-choice /= tagged-uuid-type
 ; The $measured-element-type-choice uint is intended for time series mval data where lower uint
-; values indicate older mval data while higher uint values indicate newer mval data; 0 is an asumed epoch.
+; values indicate older mval data while higher uint values indicate newer mval data; 0 is an assumed epoch.
 $measured-element-type-choice /= uint
 ; Subsequent additions to $measured-element-type-choice should be tagged values.
 


### PR DESCRIPTION
Added comments for $measured-element-type-choice = uint to classify it as a 'time series' data indicator where zero is an assumed epoch and higher numerical values represent more recent data.