### PR TITLE
factor out the build template into a separate (reusable) file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,43 +3,11 @@
 SHELL := /bin/bash
 
 include tools.mk
-
-%.cbor: %.diag
-	$(diag2cbor) $< > $@
+include funcs.mk
 
 check:: check-corim check-corim-examples
 check:: check-xcorim
 check:: check-comid check-comid-examples
-
-# $1: label
-# $2: cddl fragments
-# $3: diag test files
-define cddl_check_template
-
-check-$(1): $(1)-autogen.cddl
-	$$(cddl) $$< g 1
-
-.PHONY: check-$(1)
-
-$(1)-autogen.cddl: $(2)
-	for f in $$^ ; do ( grep -v '^;' $$$$f ; echo ) ; done > $$@
-
-CLEANFILES += $(1)-autogen.cddl
-
-check-$(1)-examples: $(1)-autogen.cddl $(3:.diag=.cbor)
-	@for f in $(3:.diag=.cbor); do \
-		echo ">> validating $$$$f against $$<" ; \
-		$$(cddl) $$< validate $$$$f &>/dev/null || exit 1 ; \
-		echo ">> saving prettified CBOR to $$$${f%.cbor}.pretty" ; \
-		$$(cbor2pretty) $$$$f > $$$${f%.cbor}.pretty ; \
-	done
-
-.PHONY: check-$(1)-examples
-
-CLEANFILES += $(3:.diag=.cbor)
-CLEANFILES += $(3:.diag=.pretty)
-
-endef # cddl_check_template
 
 COMID_FRAGS := concise-mid-tag.cddl
 COMID_FRAGS += comid-code-points.cddl

--- a/funcs.mk
+++ b/funcs.mk
@@ -1,0 +1,31 @@
+%.cbor: %.diag ; $(diag2cbor) $< > $@
+
+# $1: label
+# $2: cddl fragments
+# $3: diag test files
+define cddl_check_template
+
+check-$(1): $(1)-autogen.cddl
+	$$(cddl) $$< g 1
+
+.PHONY: check-$(1)
+
+$(1)-autogen.cddl: $(2)
+	for f in $$^ ; do ( grep -v '^;' $$$$f ; echo ) ; done > $$@
+
+CLEANFILES += $(1)-autogen.cddl
+
+check-$(1)-examples: $(1)-autogen.cddl $(3:.diag=.cbor)
+	@for f in $(3:.diag=.cbor); do \
+		echo ">> validating $$$$f against $$<" ; \
+		$$(cddl) $$< validate $$$$f &>/dev/null || exit 1 ; \
+		echo ">> saving prettified CBOR to $$$${f%.cbor}.pretty" ; \
+		$$(cbor2pretty) $$$$f > $$$${f%.cbor}.pretty ; \
+	done
+
+.PHONY: check-$(1)-examples
+
+CLEANFILES += $(3:.diag=.cbor)
+CLEANFILES += $(3:.diag=.pretty)
+
+endef # cddl_check_template


### PR DESCRIPTION
We need to be able to reuse the CoRIM build templates in the SPDM spec.